### PR TITLE
Rescue an error when no commits from branch to base branch

### DIFF
--- a/lib/ruboty/github_pr_release/actions/release.rb
+++ b/lib/ruboty/github_pr_release/actions/release.rb
@@ -27,6 +27,8 @@ module Ruboty
           message.reply("Failed in authentication (401)")
         rescue Octokit::NotFound
           message.reply("Could not find that repository")
+        rescue Octokit::UnprocessableEntity
+          message.reply("No commits between #{from_branch} and #{base}")
         rescue => exception
           message.reply("Failed by #{exception.class} #{exception}")
         rescue PrExistsError => e
@@ -39,7 +41,7 @@ module Ruboty
           Ruboty.logger.debug("from_branch (head): #{from_branch}")
           Ruboty.logger.debug("title: #{title}")
           current_pr = current_pull_request
-          raise PrExistsError, "Pull Request already exists" unless current_pr.empty? 
+          raise PrExistsError, "Pull Request already exists" unless current_pr.empty?
           client.create_pull_request(repository, base, from_branch, title, body)
         end
 


### PR DESCRIPTION
# Summary
Currently, `ruboty-github_pr_release` has no rescue `Octokit::UnprocessableEntity` error.
If the user executes the `release from user/repo:master to user/repo:deployment/production`, it will occur `Octokit::UnprocessableEntity` because the repository has no commits between `master` and `deployment/production`.

So I rescued the `Octokit::UnprocessableEntity` error.

## Error logs
```
@ruboty release from user/repo:master to user/repo:deployment/production

# Results
Failed by Octokit::UnprocessableEntity POST https://api.github.com/repos/sachin21/suehiro/pulls: 422 - Validation Failed
Error summary:
  resource: PullRequest
  code: custom
  message: No commits between deployment/production and master // See: https://developer.github.com/v3/pulls/#create-a-pull-request
```

Thank you.