### PR TITLE
Rescue an error of that occurs the release-pull-req has alredy opened

### DIFF
--- a/lib/ruboty/github_pr_release/actions/release.rb
+++ b/lib/ruboty/github_pr_release/actions/release.rb
@@ -29,6 +29,8 @@ module Ruboty
           message.reply("Could not find that repository")
         rescue Octokit::UnprocessableEntity
           message.reply("No commits between #{from_branch} and #{base}")
+        rescue PrExistsError
+          message.reply("This pull request is already open")
         rescue => exception
           message.reply("Failed by #{exception.class} #{exception}")
         rescue PrExistsError => e


### PR DESCRIPTION
# Summary

I fixed an error of that occurs the release-pull-req has alredy opened.

## Problem Summary

Currently, if the release pull-req is already opend, ruboty bot will output the raw an error message so I want to pretty output for readability.

![deploy flow for description](https://user-images.githubusercontent.com/3052342/47578919-95afbc00-d985-11e8-9831-89e786ba8112.png)
